### PR TITLE
Automatic PR for 37a090ed-a88f-4197-b261-4788c4591c53

### DIFF
--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -113,12 +113,6 @@ by : mapping, function, label, pd.Grouper or list of such
 axis : {0 or 'index', 1 or 'columns'}, default 0
     Split along rows (0) or columns (1). For `Series` this parameter
     is unused and defaults to 0.
-
-    .. deprecated:: 2.1.0
-
-        Will be removed and behave like axis=0 in a future version.
-        For ``axis=1``, do ``frame.T.groupby(...)`` instead.
-
 level : int, level name, or sequence of such, default None
     If the axis is a MultiIndex (hierarchical), group by a particular
     level or levels. Do not specify both ``by`` and ``level``.


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
DOC: updated docstring for deprecation of axis=1 in groupby (#54896)

* added deprecation for axis=1

* suggested changes