### PR TITLE
Automatic PR for 230adfef-e9b8-4bd1-8143-1fec0dc2c9d8

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -159,10 +159,10 @@ class DocBuilder:
         Open the rst file `page` and extract its title.
         """
         fname = os.path.join(SOURCE_PATH, f"{page}.rst")
-        doc = docutils.utils.new_document(
-            "<doc>",
-            docutils.frontend.get_default_settings(docutils.parsers.rst.Parser),
+        option_parser = docutils.frontend.OptionParser(
+            components=(docutils.parsers.rst.Parser,)
         )
+        doc = docutils.utils.new_document("<doc>", option_parser.get_default_values())
         with open(fname, encoding="utf-8") as f:
             data = f.read()
 


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
Fix GH #54853: BUG: DeprecationWarning for frontend.OptionParser when building docs (#54854)

* Fix GH #54853: BUG: DeprecationWarning for frontend.OptionParser when building docs

See https://github.com/docutils/docutils/commit/6548b56d9ea9a3e101cd62cfcd727b6e9e8b7ab6#diff-a033583f6ace19fed2adc108b1c130e17ea00e1afee38c22c993cb477ad27a5fR453

* Use `docutils.frontend.get_default_settings` instead of relying on `docutils.core`.

---------

Co-authored-by: Matthew Roeschke <10647082+mroeschke@users.noreply.github.com>