### PR TITLE
Automatic PR for 255c0357-f0e0-451c-a9f7-6d139d44b365

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -265,7 +265,7 @@ pc_max_seq_items = """
 """
 
 pc_max_info_rows_doc = """
-: int
+: int or None
     df.info() will usually show null-counts for each column.
     For large frames this can be quite slow. max_info_rows and max_info_cols
     limit this null check only to frames with smaller dimensions than
@@ -322,7 +322,7 @@ with cf.config_prefix("display"):
         "max_info_rows",
         1690785,
         pc_max_info_rows_doc,
-        validator=is_int,
+        validator=is_instance_factory((int, type(None))),
     )
     cf.register_option("max_rows", 60, pc_max_rows_doc, validator=is_nonnegative_int)
     cf.register_option(


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
Removes None type from max_info_rows (#54652)

* Update config_init.py

max_info_rows doesn't support None type

* Update config_init.py

changed max_info_rows validator to int type