### PR TITLE
Automatic PR for 64c49a4e-5cc2-4396-8342-d84adb2d6a8d

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -565,7 +565,10 @@ class Equals:
 
 
 class Interpolate:
-    def setup(self):
+    params = [None, "infer"]
+    param_names = ["downcast"]
+
+    def setup(self, downcast):
         N = 10000
         # this is the worst case, where every column has NaNs.
         arr = np.random.randn(N, 100)
@@ -586,11 +589,11 @@ class Interpolate:
         self.df2.loc[1::5, "A"] = np.nan
         self.df2.loc[1::5, "C"] = np.nan
 
-    def time_interpolate(self):
-        self.df.interpolate()
+    def time_interpolate(self, downcast):
+        self.df.interpolate(downcast=downcast)
 
-    def time_interpolate_some_good(self):
-        self.df2.interpolate()
+    def time_interpolate_some_good(self, downcast):
+        self.df2.interpolate(downcast=downcast)
 
 
 class Shift:


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
CLN/ASV: remove downcast param (deprecated) from frame_methods.Interpolate (#54225)

remove use of downcast param (deprecated) from frame_methods.Interpolate