### PR TITLE
Automatic PR for f071101f-50fb-4494-9205-6ecf8f84f2c6

### DIFF
--- a/pandas/tests/tseries/offsets/test_year.py
+++ b/pandas/tests/tseries/offsets/test_year.py
@@ -10,6 +10,8 @@ from datetime import datetime
 import numpy as np
 import pytest
 
+from pandas.compat import is_numpy_dev
+
 from pandas import Timestamp
 from pandas.tests.tseries.offsets.common import (
     assert_is_on_offset,
@@ -321,19 +323,12 @@ class TestYearEndDiffMonth:
         assert_is_on_offset(offset, dt, expected)
 
 
+@pytest.mark.xfail(is_numpy_dev, reason="result year is 1973, unclear why")
 def test_add_out_of_pydatetime_range():
     # GH#50348 don't raise in Timestamp.replace
     ts = Timestamp(np.datetime64("-20000-12-31"))
     off = YearEnd()
 
     result = ts + off
-    # TODO(cython3): "arg: datetime" annotation will impose
-    # datetime limitations on Timestamp. The fused type below works in cy3
-    # ctypedef fused datetimelike:
-    #     _Timestamp
-    #     datetime
-    # expected = Timestamp(np.datetime64("-19999-12-31"))
-    # assert result == expected
-    assert result.year in (-19999, 1973)
-    assert result.month == 12
-    assert result.day == 31
+    expected = Timestamp(np.datetime64("-19999-12-31"))
+    assert result == expected


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
DEBUG: CY3 test_add_out_of_pydatetime_range (#54169)

* DEBUG: CY3 test_add_out_of_pydatetime_range

* Use fused type for shift_month

* ignore annotation_typing

* Fix the test