### PR TITLE
Automatic PR for 4cc45ad6-b768-443c-8526-876f25323209

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -3,7 +3,6 @@ These benchmarks are for Series and DataFrame indexing methods.  For the
 lower-level methods directly on Index and subclasses, see index_object.py,
 indexing_engine.py, and index_cached.py
 """
-from datetime import datetime
 import warnings
 
 import numpy as np
@@ -530,27 +529,6 @@ class ChainIndexing:
             with option_context("mode.chained_assignment", mode):
                 df2 = df[df.A > N // 2]
                 df2["C"] = 1.0
-
-
-class Block:
-    params = [
-        (True, "True"),
-        (np.array(True), "np.array(True)"),
-    ]
-
-    def setup(self, true_value, mode):
-        self.df = DataFrame(
-            False,
-            columns=np.arange(500).astype(str),
-            index=date_range("2010-01-01", "2011-01-01"),
-        )
-
-        self.true_value = true_value
-
-    def time_test(self, true_value, mode):
-        start = datetime(2010, 5, 1)
-        end = datetime(2010, 9, 1)
-        self.df.loc[start:end, :] = true_value
 
 
 from .pandas_vb_common import setup  # noqa: F401 isort:skip


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
Add asv benchmarks for Block.setitem() (#53177)

* Add test for groupby with TimeGrouper

* add asv_bench for block

* add asv_bench for block

* Delete block.py , move class Block to indexing.py , as requested
and delete df.copy

* Add one more parameter to signarures seems to solve the issue

* change name to mode

* Move import to the start of the file