### PR TITLE
Automatic PR for 9c1ba6da-7b58-435c-b173-f9f7a61cc330

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -195,7 +195,7 @@ def deprecate_kwarg(
                 else:
                     new_arg_value = old_arg_value
                     msg = (
-                        f"the {repr(old_arg_name)} keyword is deprecated, "
+                        f"the {repr(old_arg_name)}' keyword is deprecated, "
                         f"use {repr(new_arg_name)} instead."
                     )
 


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
CLN: typo in deprecation message of `deprecate_kwarg` decorator (#53218)