### PR TITLE
Automatic PR for 453afc92-49d7-41d2-ab1b-303dc29ea744

### DIFF
--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -140,7 +140,10 @@ def infer_freq(
     >>> pd.infer_freq(idx)
     'D'
     """
-    from pandas.core.api import DatetimeIndex
+    from pandas.core.api import (
+        DatetimeIndex,
+        Index,
+    )
 
     if isinstance(index, ABCSeries):
         values = index._values
@@ -169,10 +172,15 @@ def infer_freq(
         inferer = _TimedeltaFrequencyInferer(index)
         return inferer.get_freq()
 
-    elif is_numeric_dtype(index.dtype):
-        raise TypeError(
-            f"cannot infer freq from a non-convertible index of dtype {index.dtype}"
-        )
+    if isinstance(index, Index) and not isinstance(index, DatetimeIndex):
+        if is_numeric_dtype(index.dtype):
+            raise TypeError(
+                f"cannot infer freq from a non-convertible index of dtype {index.dtype}"
+            )
+        # error: Incompatible types in assignment (expression has type
+        # "Union[ExtensionArray, ndarray[Any, Any]]", variable has type
+        # "Union[DatetimeIndex, TimedeltaIndex, Series, DatetimeLikeArrayMixin]")
+        index = index._values  # type: ignore[assignment]
 
     if not isinstance(index, DatetimeIndex):
         index = DatetimeIndex(index)


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
TYP: remove ignore from pandas/tseries/frequencies.py II (#53120)

* remove mypy ignore[assignment] and cast index to TimedeltaArray

* remove check index.dtype is an object

* remove cast to TimedeltaArray