### PR TITLE
Automatic PR for 8f1fc563-86a5-477a-b3bc-8a2b8505336e

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -502,7 +502,9 @@ def sanitize_masked_array(data: ma.MaskedArray) -> np.ndarray:
     if mask.any():
         dtype, fill_value = maybe_promote(data.dtype, np.nan)
         dtype = cast(np.dtype, dtype)
-        data = ma.asarray(data.astype(dtype, copy=True))
+        # Incompatible types in assignment (expression has type "ndarray[Any,
+        # dtype[Any]]", variable has type "MaskedArray[Any, Any]")
+        data = data.astype(dtype, copy=True)  # type: ignore[assignment]
         data.soften_mask()  # set hardmask False if it was True
         data[mask] = fill_value
     else:


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
TYP: remove mypy ignore from pandas/core/construction.py (#53112)

* remove ignore[assignment] from pandas/core/construction.py

* rename data

* Revert "rename data"

This reverts commit 533d841b7417dd6fb0655b2899b0af1c140c91c4.