### PR TITLE
[BAD] Automatic PR for 1ca36ea7-5c3b-4d9b-80f1-4180c6781e07

### DIFF
--- a/generate_version.py
+++ b/generate_version.py
@@ -64,4 +64,5 @@ def main():
         print(version)
 
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The PR was created automatically by CodeNarrator. The following issues were fixed:
BLD: improvements to meson.build files (#54949)

* BLD: some changes to make meson.build more idiomatic

- Use `pure: false` only in a single place. This is recommended for
  robustness, this way you can't forget it in a subdirectory and end up
  with a subtly broken package only on niche Linux distros that split
  purelib and platlib directories.
- Use `py.install_sources` with a list input rather than in a foreach
  loop.
- Remove the `werror` comment: it's never a good idea to enable
  `-Werror` by default in the build config of a library, that can easily
  break builds. This should be done in one or more CI jobs instead.

* BLD: run `generate_version.py` with a shebang, not 'python'

The way this was before can result in build failures. It assumed that
`python` is a working Python 3.x interpreter, and that is not always
true. See for example this bug report for the exact same thing in
NumPy, where `python` isn't working for Sage:
https://github.com/numpy/numpy/issues/24514

Meson guarantees that .py scripts with a shebang on the top line will
be run with a Python interpreter (if there's none on the PATH, it can
use the one Meson itself is run with). Hence this is the most robust
way of using `run_command` on a .py script.
Corresponding commit hash: 3334832eb9a8dec8928e197a2930dba018dd6160